### PR TITLE
Fix memory corruption bug in yyText()

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -532,7 +532,7 @@ YY_LOCAL(int) yyText(GREG *G, int begin, int end)\n\
     yyleng= 0;\n\
   else\n\
     {\n\
-      while (G->textlen < (yyleng - 1))\n\
+      while (G->textlen < (yyleng + 1))\n\
         {\n\
           G->textlen *= 2;\n\
           G->text= (char*)YY_REALLOC(G->text, G->textlen, G->data);\n\


### PR DESCRIPTION
In yyText() the condition for determining whether
to reallocate more space for the G->text buffer
had an "off-by-two" error, causing the null
terminator to be written into unallocated memory
in certain edge conditions (e.g. when yyleng
equaled the current size of the buffer).
