### PR TITLE
Update README to point at valid repository for wingetopt library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ With a GCC-like compiler, `make` should give you a greg executable.
 If you modify `greg.g` (greg's own grammar is written in LEG), run `make grammar` to
 regenerate `greg.c` using greg itself, then run `make` again to build it.
 
-To build with MSVC you need a getopt implementation such as [this one](https://github.com/kainjow/wingetopt).
+To build with MSVC you need a getopt implementation such as [this one](https://github.com/alex85k/wingetopt).
 
 ## Contributor guidelines
 


### PR DESCRIPTION
Current link is dead, this points to a valid repository containing the library