### PR TITLE
Capture buffer enhancements

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -506,6 +506,9 @@ static const char *preamble= "\
 #ifndef YY_BUFFER_START_SIZE\n\
 #define YY_BUFFER_START_SIZE 1024\n\
 #endif\n\
+#ifndef YY_TEXT_START_SIZE\n\
+#define YY_TEXT_START_SIZE 1024\n\
+#endif\n\
 \n\
 #ifndef YY_PART\n\
 #define yydata G->data\n\
@@ -648,7 +651,7 @@ YY_LOCAL(int) yyText(GREG *G, int begin, int end)\n\
   int yyleng= end - begin;\n\
   if (yyleng <= 0)\n\
     yyleng= 0;\n\
-  else\n\
+  else if (G->text)\n\
     {\n\
       while (G->textlen < (yyleng + 1))\n\
         {\n\
@@ -657,7 +660,7 @@ YY_LOCAL(int) yyText(GREG *G, int begin, int end)\n\
         }\n\
       memcpy(G->text, G->buf + begin, yyleng);\n\
     }\n\
-  G->text[yyleng]= '\\0';\n\
+  if (G->text) G->text[yyleng]= '\\0';\n\
   return yyleng;\n\
 }\n\
 \n\
@@ -736,8 +739,8 @@ YY_PARSE(int) YY_NAME(parse_from)(GREG *G, yyrule yystart)\n\
     {\n\
       G->buflen= YY_BUFFER_START_SIZE;\n\
       G->buf= (char*)YY_ALLOC(G->buflen, G->data);\n\
-      G->textlen= YY_BUFFER_START_SIZE;\n\
-      G->text= (char*)YY_ALLOC(G->textlen, G->data);\n\
+      G->textlen= YY_TEXT_START_SIZE;\n\
+      G->text= (char*)(G->textlen ? YY_ALLOC(G->textlen, G->data) : 0);\n\
       G->thunkslen= YY_STACK_SIZE;\n\
       G->thunks= (yythunk*)YY_ALLOC(sizeof(yythunk) * G->thunkslen, G->data);\n\
       G->valslen= YY_STACK_SIZE;\n\

--- a/compile.c
+++ b/compile.c
@@ -512,11 +512,13 @@ static const char *preamble= "\
 \n\
 #ifndef YY_PART\n\
 #define yydata G->data\n\
+#define yybuf G->buf\n\
+#define yycapture (*thunk)\n\
 #define yy G->ss\n\
 \n\
 struct _yythunk; /* forward declaration */\n\
 typedef void (*yyaction)(struct _GREG *G, char *yytext, int yyleng, struct _yythunk *thunkpos, YY_XTYPE YY_XVAR);\n\
-typedef struct _yythunk { int begin, end;  yyaction  action; const char *name; struct _yythunk *next; } yythunk;\n\
+typedef struct _yythunk { int begin, end;  yyaction  action; const char *name; } yythunk;\n\
 \n\
 typedef struct _GREG {\n\
   char *buf;\n\


### PR DESCRIPTION
This PR allows setting capture text buffer (`G->text` member) initial size separately from `G->buf` initial size. The new optional constant is `YY_TEXT_START_SIZE` with a default of 1024 to preserve current behavior.

Setting `YY_TEXT_START_SIZE` to 0 takes care for the generated parser to **not copy** capture's text to `G->text` inside internal `yyText` function. This allows for copyless strategies in actions using direct access to `G->buf` with `yycapture.begin`/`yycapture.end` which minimized string coping/allocation.

With this change alone speed-up might be significant as greg produced parsers contain a lot of "just-in-case" calls to `yyText` (e.g. before expanding `YY_BEGIN` and `YY_END` macros) and usually capture strings get copied once again in actions before getting passed on the receiving callback interface (e.g. using `strdup`) anyway.